### PR TITLE
Back to actions/download-artifact v4 to avoid issue with single artifact ...

### DIFF
--- a/.github/workflows/codecov-upload-from-artifacts.yml
+++ b/.github/workflows/codecov-upload-from-artifacts.yml
@@ -114,8 +114,8 @@ jobs:
 
       - name: Download artifacts
         # /!\ DO NOT move to v5+ until https://github.com/actions/download-artifact/issues/426 is not fixed 👇👇👇
-        # Otherwise, when only one artifact matches the pattern, the artifact name is not used parent folder,
-        # which breaks yoanm/temp-reports-group-workspace/utils/matrix-with-artifacts as the artifact name is required as parent folder
+        # Otherwise, when only one artifact matches the pattern, the artifact name is not used as parent folder,
+        # which breaks yoanm/temp-reports-group-workspace/utils/matrix-with-artifacts as the artifact name is expected to be the parent folder
         # /!\ DO NOT move to v5+ until https://github.com/actions/download-artifact/issues/426 is not fixed 👆👆👆
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/codecov-upload-from-artifacts.yml
+++ b/.github/workflows/codecov-upload-from-artifacts.yml
@@ -113,7 +113,11 @@ jobs:
             }
 
       - name: Download artifacts
-        uses: actions/download-artifact@v6
+        # /!\ DO NOT move to v5+ until https://github.com/actions/download-artifact/issues/426 is not fixed 👇👇👇
+        # Otherwise, when only one artifact matches the pattern, the artifact name is not used parent folder,
+        # which breaks yoanm/temp-reports-group-workspace/utils/matrix-with-artifacts as the artifact name is required as parent folder
+        # /!\ DO NOT move to v5+ until https://github.com/actions/download-artifact/issues/426 is not fixed 👆👆👆
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact }}
           pattern: ${{ inputs.artifacts-pattern }}


### PR DESCRIPTION
## 📑 Description
`actions/download-artifact` v5+ is broken.
When using `pattern`:
1. if there is more than one artifact matching, target folder will contains artifact names as directories
2. if there is only one artifact matching, the artifact content is directly downloaded under the target folder

-> Second case breaks yoanm/temp-reports-group-workspace/utils/matrix-with-artifacts as the artifact name is required as parent folder !

Need to wait https://github.com/actions/download-artifact/issues/426 to be resolved ....

## ✅ Checks
<!-- 
WARNING: Be sure the following task are completed before moving the PR from "Draft" to "Ready for review"
-->
Before moving to "Ready for review" mode, the following must be completed:
- [ ] `Required` CI checks are all green

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
