### PR TITLE
Fix second artifacts download for codecov

### DIFF
--- a/.github/workflows/codecov-upload-from-artifacts.yml
+++ b/.github/workflows/codecov-upload-from-artifacts.yml
@@ -165,7 +165,11 @@ jobs:
           name: "Codedov - Upload #${{ matrix.job }}"
 
       - name: Download artifacts
-        uses: actions/download-artifact@v6
+        # /!\ DO NOT move to v5+ until https://github.com/actions/download-artifact/issues/426 is not fixed 👇👇👇
+        # Otherwise, when only one artifact matches the pattern, the artifact name is not used as parent folder,
+        # which breaks yoanm/temp-reports-group-workspace/utils/matrix-with-artifacts as the artifact name is expected to be the parent folder
+        # /!\ DO NOT move to v5+ until https://github.com/actions/download-artifact/issues/426 is not fixed 👆👆👆
+        uses: actions/download-artifact@v4
         with:
           pattern: ${{ matrix.artifacts-dwl-pattern }}
           path: job-artifacts


### PR DESCRIPTION
## 📑 Description
Fix forgotten second artifact download following fix on #82 

## ✅ Checks
<!-- 
WARNING: Be sure the following task are completed before moving the PR from "Draft" to "Ready for review"
-->
Before moving to "Ready for review" mode, the following must be completed:
- [ ] `Required` CI checks are all green

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
